### PR TITLE
Converts CensusContext, CensusContext.Builder, and CensusContextFactory into abstract classes.

### DIFF
--- a/core/java/com/google/census/CensusContext.java
+++ b/core/java/com/google/census/CensusContext.java
@@ -18,18 +18,25 @@ import java.nio.ByteBuffer;
 /**
  * An immutable Census-specific context for an operation.
  */
-public interface CensusContext {
+public abstract class CensusContext {
   /** Returns a builder based on this {@link CensusContext} */
-  Builder builder();
+  public abstract Builder builder();
 
   /** Shorthand for builder().set(k1, v1).build() */
-  CensusContext with(TagKey k1, TagValue v1);
+  public final CensusContext with(TagKey k1, TagValue v1) {
+    return builder().set(k1, v1).build();
+  }
 
   /** Shorthand for builder().set(k1, v1).set(k2, v2).build() */
-  CensusContext with(TagKey k1, TagValue v1, TagKey k2, TagValue v2);
+  public final CensusContext with(TagKey k1, TagValue v1, TagKey k2, TagValue v2) {
+    return builder().set(k1, v1).set(k2, v2).build();
+  }
 
   /** Shorthand for builder().set(k1, v1).set(k2, v2).set(k3, v3).build() */
-  CensusContext with(TagKey k1, TagValue v1, TagKey k2, TagValue v2, TagKey k3, TagValue v3);
+  public final CensusContext with(
+      TagKey k1, TagValue v1, TagKey k2, TagValue v2, TagKey k3, TagValue v3) {
+    return builder().set(k1, v1).set(k2, v2).set(k3, v3).build();
+  }
 
   /**
    * Records the given metrics against this {@link CensusContext}.
@@ -37,20 +44,20 @@ public interface CensusContext {
    * @param metrics the metrics to record against the saved {@link CensusContext}
    * @return this
    */
-  CensusContext record(MetricMap metrics);
+  public abstract CensusContext record(MetricMap metrics);
 
   /**
    * Serializes the {@link CensusContext} into the on-the-wire representation.
    *
    * @return serialized bytes.
    */
-  ByteBuffer serialize();
+  public abstract ByteBuffer serialize();
 
   /** Sets the current thread-local {@link CensusContext}. */
-  void setCurrent();
+  public abstract void setCurrent();
 
   /** Builder for {@link CensusContext}. */
-  interface Builder {
+  public abstract static class Builder {
     /**
      * Associates the given tag key with the given tag value.
      *
@@ -58,11 +65,11 @@ public interface CensusContext {
      * @param value the value to be associated with {@code key}
      * @return {@code this}
      */
-    Builder set(TagKey key, TagValue value);
+    public abstract Builder set(TagKey key, TagValue value);
 
     /**
      * Builds a {@link CensusContext} from the specified keys and values.
      */
-    CensusContext build();
+    public abstract CensusContext build();
   }
 }

--- a/core/java/com/google/census/CensusContextFactory.java
+++ b/core/java/com/google/census/CensusContextFactory.java
@@ -20,18 +20,18 @@ import javax.annotation.Nullable;
 /**
  * Factory class for {@link CensusContext}.
  */
-public interface CensusContextFactory {
+public abstract class CensusContextFactory {
   /** Creates a new {@link CensusContext} built from the given on-the-wire encoded representation.
    *
    * @param buffer on-the-wire representation of a {@link CensusContext}
    * @return a {@link CensusContext} deserialized from {@code buffer}
    */
   @Nullable
-  CensusContext deserialize(ByteBuffer buffer);
+  public abstract CensusContext deserialize(ByteBuffer buffer);
 
   /** Returns the current thread-local {@link CensusContext}. */
-  CensusContext getCurrent();
+  public abstract CensusContext getCurrent();
 
   /** Returns the default {@link CensusContext}. */
-  CensusContext getDefault();
+  public abstract CensusContext getDefault();
 }

--- a/core_native/java/com/google/census/CensusContextFactoryImpl.java
+++ b/core_native/java/com/google/census/CensusContextFactoryImpl.java
@@ -19,7 +19,7 @@ import java.util.HashMap;
 import javax.annotation.Nullable;
 
 /** Native Implementation of {@link CensusContextFactory} */
-class CensusContextFactoryImpl implements CensusContextFactory {
+final class CensusContextFactoryImpl extends CensusContextFactory {
   static final CensusContextImpl DEFAULT = new CensusContextImpl(new HashMap<String, String>(0));
 
   /**

--- a/core_native/java/com/google/census/CensusContextImpl.java
+++ b/core_native/java/com/google/census/CensusContextImpl.java
@@ -17,7 +17,7 @@ import java.nio.ByteBuffer;
 import java.util.HashMap;
 
 /** Native Implementation of {@link CensusContext} */
-final class CensusContextImpl implements CensusContext {
+final class CensusContextImpl extends CensusContext {
   final HashMap<String, String> tags;
 
   CensusContextImpl(HashMap<String, String> tags) {
@@ -27,22 +27,6 @@ final class CensusContextImpl implements CensusContext {
   @Override
   public Builder builder() {
     return new Builder(tags);
-  }
-
-  @Override
-  public CensusContext with(TagKey k1, TagValue v1) {
-    return builder().set(k1, v1).build();
-  }
-
-  @Override
-  public CensusContext with(TagKey k1, TagValue v1, TagKey k2, TagValue v2) {
-    return builder().set(k1, v1).set(k2, v2).build();
-  }
-
-  @Override
-  public CensusContext with(
-      TagKey k1, TagValue v1, TagKey k2, TagValue v2, TagKey k3, TagValue v3) {
-    return builder().set(k1, v1).set(k2, v2).set(k3, v3).build();
   }
 
   @Override
@@ -75,7 +59,7 @@ final class CensusContextImpl implements CensusContext {
     return tags.toString();
   }
 
-  private static final class Builder implements CensusContext.Builder {
+  private static final class Builder extends CensusContext.Builder {
     private final HashMap<String, String> tags;
 
     private Builder(HashMap<String, String> tags) {


### PR DESCRIPTION
This will allow us to add methods without breaking existing implementations. Fixes issue #6.