### PR TITLE
Makes census-java compatible with Java 6

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "proto"]
 	path = proto
-	url = https://github.com/google/census-proto
+	url = https://github.com/google/census-proto.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,35 @@ sudo: required
 dist: trusty
 language: java
 
-jdk:
-  - oraclejdk8
+matrix:
+  include:
+  - jdk: openjdk6
+    env: BUILD=MVN
+
+  - jdk: oraclejdk7
+    env: BUILD=MVN
+
+  - jdk: oraclejdk8
+    env: BUILD=BAZEL
 
 before_install:
-  - echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
-  - curl https://storage.googleapis.com/bazel-apt/doc/apt-key.pub.gpg | sudo apt-key add -
-  - sudo apt-get update
+  - case "$BUILD" in
+      "BAZEL")
+        echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list ;
+        curl https://storage.googleapis.com/bazel-apt/doc/apt-key.pub.gpg | sudo apt-key add - ;
+        sudo apt-get update ;;
+    esac
 
 install:
-  - sudo apt-get install bazel
+  - case "$BUILD" in
+      "BAZEL")
+        sudo apt-get install bazel ;;
+    esac
 
 script:
-  - bazel test ...
+  - case "$BUILD" in
+      "BAZEL")
+        bazel test ... ;;
+      "MVN")
+        mvn package ;;
+    esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ matrix:
     env: BUILD=MVN
 
   - jdk: oraclejdk8
+    env: BUILD=MVN
+
+  - jdk: oraclejdk8
     env: BUILD=BAZEL
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,14 @@ install:
   - case "$BUILD" in
       "BAZEL")
         sudo apt-get install bazel ;;
+      "MVN")
+        mkdir protoc ;
+        cd protoc ;
+        curl -L -o protoc.zip https://github.com/google/protobuf/releases/download/v3.0.2/protoc-3.0.2-linux-x86_64.zip ;
+        unzip protoc.zip ;
+        export PATH=`pwd`/bin/:$PATH ;
+        protoc --version ;
+        cd .. ;;
     esac
 
 script:

--- a/core/java/com/google/census/CensusContext.java
+++ b/core/java/com/google/census/CensusContext.java
@@ -49,8 +49,8 @@ public abstract class CensusContext {
   /**
    * Serializes the {@link CensusContext} into the on-the-wire representation.
    *
-   * <p>The inverse of {@link CensusContextFactory#deserialize()} and should be based on the
-   * {@link CensusContext} protobuf representation.
+   * <p>The inverse of {@link CensusContextFactory#deserialize(ByteBuffer)} and should be based on
+   * the {@link CensusContext} protobuf representation.
    *
    * @return serialized bytes.
    */

--- a/core/java/com/google/census/CensusScope.java
+++ b/core/java/com/google/census/CensusScope.java
@@ -13,6 +13,8 @@
 
 package com.google.census;
 
+import java.io.Closeable;
+
 /**
  * {@link CensusScope} defines an arbitrary scope of code as a traceable operation. Supports
  * try-with-resources idiom.
@@ -31,7 +33,7 @@ package com.google.census;
  * }
  * </pre>
  */
-public final class CensusScope implements AutoCloseable {
+public final class CensusScope implements Closeable {
   private final CensusContext saved;
 
   /**

--- a/core/java/com/google/census/MetricMap.java
+++ b/core/java/com/google/census/MetricMap.java
@@ -107,7 +107,7 @@ public class MetricMap implements Iterable<Metric> {
       return new MetricMap(metrics);
     }
 
-    private ArrayList<Metric> metrics = new ArrayList<>();
+    private ArrayList<Metric> metrics = new ArrayList<Metric>();
 
     private Builder() {
     }

--- a/core/java/com/google/census/Provider.java
+++ b/core/java/com/google/census/Provider.java
@@ -42,7 +42,10 @@ class Provider<T> {
       if (provider != null) {
         return (T) provider.newInstance();
       }
-    } catch (InstantiationException | IllegalAccessException e) {
+    } catch (InstantiationException e) {
+      // TODO(dpo): decide what to do here - log, crash, or both.
+      System.err.println(e);
+    } catch (IllegalAccessException e) {
       // TODO(dpo): decide what to do here - log, crash, or both.
       System.err.println(e);
     }

--- a/core/javatests/com/google/census/CensusScopeTest.java
+++ b/core/javatests/com/google/census/CensusScopeTest.java
@@ -41,58 +41,76 @@ public class CensusScopeTest {
 
   @Test
   public void testScope() {
-    try (CensusScope scope = new CensusScope(Census.getCurrent().with(K1, V1))) {
+    CensusScope scope = new CensusScope(Census.getCurrent().with(K1, V1));
+    try {
       assertEquals(
           Census.getDefault().with(K1, V1),
           Census.getCurrent());
+    } finally {
+      scope.close();
     }
     assertEquals(Census.getDefault(), Census.getCurrent());
   }
 
   @Test
   public void testNestedScope() {
-    try (CensusScope s1 = new CensusScope(Census.getCurrent().with(K1, V1))) {
+    CensusScope s1 = new CensusScope(Census.getCurrent().with(K1, V1));
+    try {
       assertEquals(
           Census.getDefault().with(K1, V1),
           Census.getCurrent());
-      try (CensusScope s2 = new CensusScope(Census.getCurrent().with(K2, V2))) {
+      CensusScope s2 = new CensusScope(Census.getCurrent().with(K2, V2));
+      try {
         assertEquals(
             Census.getDefault().with(K1, V1).with(K2, V2),
             Census.getCurrent());
+      } finally {
+        s2.close();
       }
       assertEquals(
           Census.getDefault().with(K1, V1),
           Census.getCurrent());
+    } finally {
+      s1.close();
     }
     assertEquals(Census.getDefault(), Census.getCurrent());
   }
 
   @Test
   public void testOf1() {
-    try (CensusScope scope = CensusScope.of(K1, V1)) {
+    CensusScope scope = CensusScope.of(K1, V1);
+    try {
       assertEquals(
           Census.getDefault().with(K1, V1),
           Census.getCurrent());
+    } finally {
+      scope.close();
     }
     assertEquals(Census.getDefault(), Census.getCurrent());
   }
 
   @Test
   public void testOf2() {
-    try (CensusScope scope = CensusScope.of(K1, V1, K2, V2)) {
+    CensusScope scope = CensusScope.of(K1, V1, K2, V2);
+    try {
       assertEquals(
           Census.getDefault().with(K1, V1, K2, V2),
           Census.getCurrent());
+    } finally {
+      scope.close();
     }
     assertEquals(Census.getDefault(), Census.getCurrent());
   }
 
   @Test
   public void testOf3() {
-    try (CensusScope scope = CensusScope.of(K1, V1, K2, V2, K3, V3)) {
+    CensusScope scope = CensusScope.of(K1, V1, K2, V2, K3, V3);
+    try {
       assertEquals(
           Census.getDefault().with(K1, V1, K2, V2, K3, V3),
           Census.getCurrent());
+    } finally {
+      scope.close();
     }
     assertEquals(Census.getDefault(), Census.getCurrent());
   }
@@ -101,10 +119,13 @@ public class CensusScopeTest {
   public void testBuilder() {
     CensusScope.Builder builder =
         CensusScope.builder().set(K1, V1).set(K2, V2).set(K3, V3).set(K4, V4);
-    try (CensusScope scope = builder.build()) {
+    CensusScope scope = builder.build();
+    try {
       assertEquals(
           Census.getDefault().builder().set(K1, V1).set(K2, V2).set(K3, V3).set(K4, V4).build(),
           Census.getCurrent());
+    } finally {
+      scope.close();
     }
     assertEquals(Census.getDefault(), Census.getCurrent());
   }

--- a/core/javatests/com/google/census/MetricMapTest.java
+++ b/core/javatests/com/google/census/MetricMapTest.java
@@ -62,7 +62,7 @@ public class MetricMapTest {
 
   @Test
   public void testBuilder() {
-    ArrayList<Metric> expected = new ArrayList<>(10);
+    ArrayList<Metric> expected = new ArrayList<Metric>(10);
     MetricMap.Builder builder = MetricMap.builder();
     for (int i = 1; i <= 10; i++) {
       expected.add(new Metric(new MetricName("m" + i), i * 11.1));

--- a/core/javatests/com/google/census/ProviderTest.java
+++ b/core/javatests/com/google/census/ProviderTest.java
@@ -26,7 +26,7 @@ import org.junit.runners.JUnit4;
 public class ProviderTest {
   @Test
   public void testGoodClass() throws Exception {
-    Provider<GetGen> provider = new Provider<>("com.google.census.ProviderTest$GetGen");
+    Provider<GetGen> provider = new Provider<GetGen>("com.google.census.ProviderTest$GetGen");
     GetGen getGen0 = provider.newInstance();
     assertThat(getGen0.getGen()).isEqualTo(0);
     for (int i = 1; i < 10; i++) {
@@ -37,7 +37,7 @@ public class ProviderTest {
 
   @Test
   public void testBadClass() throws Exception {
-    Provider<GetGen> provider = new Provider<>("com.google.census.ProviderTest$BadClass");
+    Provider<GetGen> provider = new Provider<GetGen>("com.google.census.ProviderTest$BadClass");
     assertThat(provider).isNotNull();
     assertThat(provider.newInstance()).isNull();
   }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,4 +15,45 @@
     <artifactId>census-parent</artifactId>
     <version>0.1.0-SNAPSHOT</version>
   </parent>
+  <build>
+    <sourceDirectory>java</sourceDirectory>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.3.1</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.1.2</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.8.1</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/core_native/java/com/google/census/CensusContextFactoryImpl.java
+++ b/core_native/java/com/google/census/CensusContextFactoryImpl.java
@@ -22,7 +22,7 @@ final class CensusContextFactoryImpl extends CensusContextFactory {
   static final CensusContextImpl DEFAULT = new CensusContextImpl(new HashMap<String, String>(0));
 
   /**
-   * Deserializes a {@link CensusContextImpl} from a serialized {@link CensusContextProto}.
+   * Deserializes a {@link CensusContextImpl} from a serialized {@code CensusContextProto}.
    *
    * <p>The encoded tags are of the form: {@code <tag prefix> + 'key' + <tag delim> + 'value'}*
    */

--- a/core_native/java/com/google/census/CensusContextImpl.java
+++ b/core_native/java/com/google/census/CensusContextImpl.java
@@ -68,7 +68,7 @@ final class CensusContextImpl extends CensusContext {
     private final HashMap<String, String> tags;
 
     private Builder(HashMap<String, String> tags) {
-      this.tags = new HashMap<>(tags);
+      this.tags = new HashMap<String, String>(tags);
     }
 
     @Override
@@ -79,7 +79,7 @@ final class CensusContextImpl extends CensusContext {
 
     @Override
     public CensusContext build() {
-      return new CensusContextImpl(new HashMap<>(tags));
+      return new CensusContextImpl(new HashMap<String, String>(tags));
     }
   }
 }

--- a/core_native/java/com/google/census/CensusContextImpl.java
+++ b/core_native/java/com/google/census/CensusContextImpl.java
@@ -35,7 +35,7 @@ final class CensusContextImpl extends CensusContext {
   }
 
   /**
-   * Serializes a {@link CensusContextImpl} into {@link CensusContextProto} serialized format.
+   * Serializes a {@link CensusContextImpl} into {@code CensusContextProto} serialized format.
    *
    * <p>The encoded tags are of the form: {@code <tag prefix> + 'key' + <tag delim> + 'value'}*
    */

--- a/core_native/java/com/google/census/CensusSerializer.java
+++ b/core_native/java/com/google/census/CensusSerializer.java
@@ -50,13 +50,15 @@ final class CensusSerializer {
       CensusContextProto.CensusContext context =
           CensusContextProto.CensusContext.parser().parseFrom(buffer.array());
       return new CensusContextImpl(tagsFromString(context.getTags()));
-    } catch (IllegalArgumentException | InvalidProtocolBufferException e) {
+    } catch (IllegalArgumentException e) {
+      return null;
+    } catch (InvalidProtocolBufferException e) {
       return null;
     }
   }
 
   private static HashMap<String, String> tagsFromString(String encoded) {
-    HashMap<String, String> tags = new HashMap<>();
+    HashMap<String, String> tags = new HashMap<String, String>();
     int length = encoded.length();
     int index = 0;
     while (index != length) {

--- a/core_native/pom.xml
+++ b/core_native/pom.xml
@@ -22,11 +22,50 @@
       <artifactId>census-core</artifactId>
       <version>0.1.0-SNAPSHOT</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.census</groupId>
+      <artifactId>census-proto</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+    </dependency>
   </dependencies>
   <build>
+    <sourceDirectory>java</sourceDirectory>
     <plugins>
       <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.3.1</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.1.2</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.8.1</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
         <configuration>
           <show>private</show>
         </configuration>

--- a/examples/java/com/google/census/CensusRunner.java
+++ b/examples/java/com/google/census/CensusRunner.java
@@ -39,17 +39,23 @@ public class CensusRunner {
     System.out.println("Hello Census World");
     System.out.println("Default Tags: " + Census.getDefault());
     System.out.println("Current Tags: " + Census.getCurrent());
-    try (CensusScope scope1 = CensusScope.of(K1, V1, K2, V2)) {
+    CensusScope scope1 = CensusScope.of(K1, V1, K2, V2);
+    try {
         CensusContext context1 = Census.getDefault().with(K1, V1, K2, V2);
         System.out.println("  Current Tags: " + Census.getCurrent());
         System.out.println("  Current == Default + tags1: " + Census.getCurrent().equals(context1));
-        try (CensusScope scope2 = CensusScope.of(K3, V3, K4, V4)) {
+        CensusScope scope2 = CensusScope.of(K3, V3, K4, V4);
+        try {
             CensusContext context2 = context1.with(K3, V3, K4, V4);
             System.out.println("    Current Tags: " + Census.getCurrent());
             System.out.println("    Current == Default + tags1 + tags2: "
                 + Census.getCurrent().equals(context2));
             Census.getCurrent().record(MetricMap.of(M1, 0.2, M2, 0.4));
+        } finally {
+          scope2.close();
         }
+    } finally {
+      scope1.close();
     }
     System.out.println("Current == Default: " +
         Census.getCurrent().equals(Census.getDefault()));

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.5.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
   <modules>
     <module>core</module>
     <module>core_native</module>
+    <module>proto</module>
   </modules>
 
   <dependencies>
@@ -48,45 +49,4 @@
       <version>3.0.0</version>
     </dependency>
   </dependencies>
-  <build>
-    <sourceDirectory>java</sourceDirectory>
-    <plugins>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
-        <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>2.3.1</version>
-      </plugin>
-      <plugin>
-        <artifactId>maven-source-plugin</artifactId>
-        <version>2.1.2</version>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar-no-fork</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.8.1</version>
-        <executions>
-          <execution>
-            <id>attach-javadocs</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>


### PR DESCRIPTION
This PR includes #2, because it uses the Maven build files to build with Java 6 and 7 in .travis.yml.