### PR TITLE
Removes dependency on guava from census-core.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -15,10 +15,7 @@
 java_library(
     name = "census-core",
     srcs = glob(["core/java/com/google/census/*.java"]),
-    deps = [
-        "@guava//jar",
-        "@jsr305//jar",
-    ],
+    deps = ["@jsr305//jar"],
 )
 
 java_library(
@@ -27,7 +24,6 @@ java_library(
     deps = [
         ":census-core",
         "//proto:census_context-proto-java",
-        "@guava//jar",
         "@jsr305//jar",
         "@protobuf//jar",
     ],

--- a/core/java/com/google/census/MetricMap.java
+++ b/core/java/com/google/census/MetricMap.java
@@ -13,9 +13,8 @@
 
 package com.google.census;
 
-import com.google.common.collect.UnmodifiableIterator;
-
 import java.util.ArrayList;
+import java.util.Iterator;
 
 /**
  * A map from Census metric names to metric values.
@@ -59,11 +58,12 @@ public class MetricMap implements Iterable<Metric> {
   }
 
   /**
-   * Returns an {@link UnmodifiableIterator} over the name/value mappings in this {@link MetricMap}.
+   * Returns an {@link Iterator} over the name/value mappings in this {@link MetricMap}. The
+   * {@code Iterator} does not support {@link Iterator#remove()}.
    */
   @Override
-  public UnmodifiableIterator<Metric> iterator() {
-    return new Iterator();
+  public Iterator<Metric> iterator() {
+    return new MetricMapIterator();
   }
 
   private final ArrayList<Metric> metrics;
@@ -113,14 +113,19 @@ public class MetricMap implements Iterable<Metric> {
     }
   }
 
-  // Provides an UnmodifiableIterator over this instance's metrics.
-  private class Iterator extends UnmodifiableIterator<Metric> {
+  // Provides an unmodifiable Iterator over this instance's metrics.
+  private class MetricMapIterator implements Iterator<Metric> {
     @Override public boolean hasNext() {
       return position < length;
     }
 
     @Override public Metric next() {
       return metrics.get(position++);
+    }
+
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException();
     }
 
     private final int length = metrics.size();

--- a/core/java/com/google/census/RpcConstants.java
+++ b/core/java/com/google/census/RpcConstants.java
@@ -13,8 +13,6 @@
 
 package com.google.census;
 
-import com.google.common.annotations.VisibleForTesting;
-
 /**
  * Census constants for collecting rpc stats.
  */
@@ -38,7 +36,8 @@ public final class RpcConstants {
   public static final MetricName RPC_SERVER_BYTES_SENT = new MetricName("/rpc/server/bytes_sent");
   public static final MetricName RPC_SERVER_LATENCY = new MetricName("/rpc/server/latency");
 
-  @VisibleForTesting RpcConstants() {
+  //Visible for testing
+  RpcConstants() {
     throw new AssertionError();
   }
 }


### PR DESCRIPTION
This fixes #13. Another way to document methods that can return null is to add a new Nullable class to census-core.