### PR TITLE
Cleanup

### DIFF
--- a/core/java/com/google/census/MetricMap.java
+++ b/core/java/com/google/census/MetricMap.java
@@ -107,7 +107,7 @@ public class MetricMap implements Iterable<Metric> {
       return new MetricMap(metrics);
     }
 
-    private ArrayList<Metric> metrics = new ArrayList<Metric>();
+    private final ArrayList<Metric> metrics = new ArrayList<Metric>();
 
     private Builder() {
     }

--- a/core/java/com/google/census/Provider.java
+++ b/core/java/com/google/census/Provider.java
@@ -13,6 +13,8 @@
 
 package com.google.census;
 
+import java.lang.reflect.InvocationTargetException;
+
 /**
  * Census-specific service provider mechanism.
  *
@@ -40,12 +42,18 @@ class Provider<T> {
   T newInstance() {
     try {
       if (provider != null) {
-        return (T) provider.newInstance();
+        return (T) provider.getConstructor().newInstance();
       }
     } catch (InstantiationException e) {
       // TODO(dpo): decide what to do here - log, crash, or both.
       System.err.println(e);
     } catch (IllegalAccessException e) {
+      // TODO(dpo): decide what to do here - log, crash, or both.
+      System.err.println(e);
+    } catch (NoSuchMethodException e) {
+      // TODO(dpo): decide what to do here - log, crash, or both.
+      System.err.println(e);
+    } catch (InvocationTargetException e) {
       // TODO(dpo): decide what to do here - log, crash, or both.
       System.err.println(e);
     }

--- a/core/javatests/com/google/census/TagTest.java
+++ b/core/javatests/com/google/census/TagTest.java
@@ -38,15 +38,9 @@ public final class TagTest {
     assertThat(new Tag("key", "val").getValue()).isEqualTo("val");
   }
 
-  @Test
+  @Test(expected = UnsupportedOperationException.class)
   public void testSetValue() {
-    boolean fail = true;
-    try {
-      new Tag("key", "val").setValue("val1");
-      fail = false;
-    } catch (UnsupportedOperationException expected) {
-    }
-    assertThat(fail).isTrue();
+    new Tag("key", "val").setValue("val1");
   }
 
   @Test

--- a/core_native/java/com/google/census/CensusContextFactoryImpl.java
+++ b/core_native/java/com/google/census/CensusContextFactoryImpl.java
@@ -21,6 +21,8 @@ import javax.annotation.Nullable;
 final class CensusContextFactoryImpl extends CensusContextFactory {
   static final CensusContextImpl DEFAULT = new CensusContextImpl(new HashMap<String, String>(0));
 
+  public CensusContextFactoryImpl() {}
+
   /**
    * Deserializes a {@link CensusContextImpl} from a serialized {@code CensusContextProto}.
    *

--- a/examples/java/com/google/census/CensusRunner.java
+++ b/examples/java/com/google/census/CensusRunner.java
@@ -11,18 +11,13 @@
  * limitations under the License.
  */
 
-package com.google.census.examples;
-
-import com.google.census.Census;
-import com.google.census.CensusContext;
-import com.google.census.CensusGrpcContext;
-import com.google.census.MetricMap;
-import com.google.census.MetricName;
-import com.google.census.TagKey;
-import com.google.census.TagValue;
+package com.google.census;
 
 import io.grpc.Context;
 
+/**
+ * Simple program that uses Census contexts.
+ */
 public class CensusRunner {
   private static final TagKey K1 = new TagKey("k1");
   private static final TagKey K2 = new TagKey("k2");
@@ -37,7 +32,7 @@ public class CensusRunner {
   private static final MetricName M1 = new MetricName("m1");
   private static final MetricName M2 = new MetricName("m2");
 
-  public static void main(String args[]) {
+  public static void main(String[] args) {
     System.out.println("Hello Census World");
     System.out.println("Default Tags: " + DEFAULT);
     System.out.println("Current Tags: " + getCurrentCensusContext());


### PR DESCRIPTION
This PR uses `Class.getConstructor().newInstance()` instead of `Class.newInstance()` to instantiate `CensusContextFactoryImpl`, and makes a few other minor changes.