### PR TITLE
Runs Maven FindBugs plugin.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,5 +43,5 @@ script:
       "BAZEL")
         bazel test ... ;;
       "MVN")
-        mvn package ;;
+        mvn verify ;;
     esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,5 +43,10 @@ script:
       "BAZEL")
         bazel test ... ;;
       "MVN")
-        mvn verify ;;
+        case "$TRAVIS_JDK_VERSION" in
+          "openjdk6")
+            mvn verify -P java6 ;;
+          *)
+            mvn verify ;;
+        esac
     esac

--- a/core/java/com/google/census/MetricMap.java
+++ b/core/java/com/google/census/MetricMap.java
@@ -15,6 +15,7 @@ package com.google.census;
 
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 /**
  * A map from Census metric names to metric values.
@@ -120,6 +121,9 @@ public class MetricMap implements Iterable<Metric> {
     }
 
     @Override public Metric next() {
+      if (position >= metrics.size()) {
+        throw new NoSuchElementException();
+      }
       return metrics.get(position++);
     }
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -54,22 +54,37 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.4</version>
-        <configuration>
-          <effort>Max</effort>
-          <threshold>Low</threshold>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>findbugs-maven-plugin</artifactId>
+            <version>3.0.4</version>
+            <configuration>
+              <effort>Max</effort>
+              <threshold>Low</threshold>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>java6</id>
+    </profile>
+  </profiles>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -54,6 +54,22 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <version>3.0.4</version>
+        <configuration>
+          <effort>Max</effort>
+          <threshold>Low</threshold>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/core_native/pom.xml
+++ b/core_native/pom.xml
@@ -70,22 +70,37 @@
           <show>private</show>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.4</version>
-        <configuration>
-          <effort>Max</effort>
-          <threshold>Low</threshold>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>findbugs-maven-plugin</artifactId>
+            <version>3.0.4</version>
+            <configuration>
+              <effort>Max</effort>
+              <threshold>Low</threshold>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>java6</id>
+    </profile>
+  </profiles>
 </project>

--- a/core_native/pom.xml
+++ b/core_native/pom.xml
@@ -70,6 +70,22 @@
           <show>private</show>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <version>3.0.4</version>
+        <configuration>
+          <effort>Max</effort>
+          <threshold>Low</threshold>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
This PR also fixes an existing warning and creates a separate build profile for Java 6.  The Java 6 profile skips the FindBugs check, which requires Java 7.